### PR TITLE
Advanced Search show/hide bugfix

### DIFF
--- a/view/css/custom1.css
+++ b/view/css/custom1.css
@@ -166,6 +166,9 @@ prm-search-bookmark-filter #fixed-buttons-holder #favorites-button md-icon svg {
 	should prevent its collapse. I copied the selector, but "prm-search-bar .shrink-content"
 	was the original selector we were interested in and that's the one I've added some
 	specificity to.
+
+	As of the May release, we also have a display: none !important; rule we need to deal
+	with, but only on the search fields. For some reason.
 */
 prm-atoz-search-bar .shrink-content,
 prm-browse-search-bar .shrink-content,
@@ -173,6 +176,14 @@ prm-newspapers-search-bar .shrink-content,
 prm-search-bar .shrink-content.advanced-search-tabs,
 prm-tags-search-bar .shrink-content {
 	max-height: fit-content;
+}
+
+div.advanced-search-tabs md-card fieldset .ng-hide:not(.ng-hide-animate) {
+	display: block !important; /* YES we need !important, to override ANOTHER !important... */
+}
+
+prm-advanced-search form button.collapsed-button prm-icon[icon-definition="chevron-up"] {
+	display: none;
 }
 
 /* Moving Top of Page Arrow Color Hover*/


### PR DESCRIPTION
This does two things:

1. It overrides some new styling that targets search fields in the advanced search and display:nones them in certain situations.
2. It hides the minimize/maximize indicator (chevron) next to the advanced search heading.

Test in sandbox here:
https://pitt-psb.primo.exlibrisgroup.com/discovery/search?vid=01PITT_INST:a_search&mode=advanced
Test in "production" on a test view here:
https://pitt.primo.exlibrisgroup.com/discovery/search?vid=01PITT_INST:a_search&mode=advanced
Test in "production on a test view with the link from library.pitt.edu as currently constructed:
https://pitt.primo.exlibrisgroup.com/discovery/search?query=any,contains,*&tab=Everything&search_scope=MyInst_and_CI&vid=01PITT_INST:a_search&lang=en&offset=0&mode=advanced

I've tested with all the use-cases I know about, with search queries and without, with extra fields, and so on. It seems pretty robust.