### PR TITLE
replaced url

### DIFF
--- a/view/js/uls-libAnswersChatWidget.js
+++ b/view/js/uls-libAnswersChatWidget.js
@@ -11,7 +11,7 @@ function chatWidget() {
 	else {
 		protocol='http://';
 	}
-	lc.src = protocol + 'pitt.libanswers.com/chat/widget/a962140fb4e6ffbcdae688be4c64cba5';
+	lc.src = protocol + 'pitt.libanswers.com/load_chat.php?hash=682f0a4cbcf434ef0a11eeab9cddf016';
 	var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(lc, s);
 }
 


### PR DESCRIPTION
New widgets automatically generate embed code that works with the new api. I cloned ours and grabbed the suggested script url.  I think we still need to use the load_chat.php script, but just at the new address.  